### PR TITLE
Add an option to generate type stubs files

### DIFF
--- a/com/win32com/client/genpy.py
+++ b/com/win32com/client/genpy.py
@@ -658,7 +658,16 @@ class CoClassItem(build.OleItem, WritableItem):
       print("# This CoClass is known by the name '%s'" % (progId), file=stream)
     except pythoncom.com_error:
       pass
-    baseClass = "CoClassBaseClass" if generator.typeHints != TYPE_HINTS_STUBS_ONLY else "typing.Protocol"
+
+    baseClass = "CoClassBaseClass"
+    if generator.typeHints == TYPE_HINTS_STUBS_ONLY:
+        baseClasses = []
+        for item, flag in self.interfaces:
+            # If we have written a class use it as the base class
+            if item.bWritten:
+                baseClasses.append(item.python_name)
+        baseClass = ", ".join(baseClasses) if baseClasses else "typing.Protocol"
+
     print('class %s(%s): # A CoClass' % (self.python_name, baseClass), file=stream)
     if doc and doc[1]: print('\t# ' + doc[1], file=stream)
     if generator.typeHints == TYPE_HINTS_STUBS_ONLY:


### PR DESCRIPTION
Thanks for your work adding type hints!

This PR extends that so that it's possible to generate pyi files that use the typing.Protocol class. This enables IDEs to do auto-completion and type checking even if the actual type is still generated at runtime.

I see your PR on the main repo is still outstanding so I didn't want to raise another one there. I also thought you might prefer to get that through before making any more changes like this one!

Run "makepy.py --type-hints=stubs" to generate a .pyi file. Using just "-t" leaves the behaviour the same as it is now.